### PR TITLE
fix: add ability to pass query params to Get() dns resources and records

### DIFF
--- a/api/dns_resource_records.go
+++ b/api/dns_resource_records.go
@@ -7,6 +7,6 @@ import (
 // DNSResourceRecords is an interface for listing and creaing
 // DNSResourceRecord records
 type DNSResourceRecords interface {
-	Get() ([]entity.DNSResourceRecord, error)
+	Get(params *entity.DNSResourceRecordsParams) ([]entity.DNSResourceRecord, error)
 	Create(params *entity.DNSResourceRecordParams) (*entity.DNSResourceRecord, error)
 }

--- a/api/dns_resources.go
+++ b/api/dns_resources.go
@@ -7,6 +7,6 @@ import (
 // DNSResources is an interface for listing and creating
 // DNSResource records
 type DNSResources interface {
-	Get() ([]entity.DNSResource, error)
+	Get(params *entity.DNSResourcesParams) ([]entity.DNSResource, error)
 	Create(params *entity.DNSResourceParams) (*entity.DNSResource, error)
 }

--- a/client/dns_resource_records.go
+++ b/client/dns_resource_records.go
@@ -3,7 +3,6 @@ package client
 
 import (
 	"encoding/json"
-	"net/url"
 
 	"github.com/canonical/gomaasclient/entity"
 	"github.com/google/go-querystring/query"
@@ -19,9 +18,14 @@ func (d *DNSResourceRecords) client() APIClient {
 }
 
 // Get fetches a list of DNSResourceRecord objectts
-func (d *DNSResourceRecords) Get() ([]entity.DNSResourceRecord, error) {
+func (d *DNSResourceRecords) Get(params *entity.DNSResourceRecordsParams) ([]entity.DNSResourceRecord, error) {
+	qsp, err := query.Values(params)
+	if err != nil {
+		return nil, err
+	}
+
 	dnsResourceRecords := make([]entity.DNSResourceRecord, 0)
-	err := d.client().Get("", url.Values{}, func(data []byte) error {
+	err = d.client().Get("", qsp, func(data []byte) error {
 		return json.Unmarshal(data, &dnsResourceRecords)
 	})
 

--- a/client/dns_resources.go
+++ b/client/dns_resources.go
@@ -3,7 +3,6 @@ package client
 
 import (
 	"encoding/json"
-	"net/url"
 
 	"github.com/canonical/gomaasclient/entity"
 	"github.com/google/go-querystring/query"
@@ -19,9 +18,14 @@ func (d *DNSResources) client() APIClient {
 }
 
 // Get fetches a list of DNSResource objects
-func (d *DNSResources) Get() ([]entity.DNSResource, error) {
+func (d *DNSResources) Get(params *entity.DNSResourcesParams) ([]entity.DNSResource, error) {
+	qsp, err := query.Values(params)
+	if err != nil {
+		return nil, err
+	}
+
 	dnsresources := make([]entity.DNSResource, 0)
-	err := d.client().Get("", url.Values{}, func(data []byte) error {
+	err = d.client().Get("", qsp, func(data []byte) error {
 		return json.Unmarshal(data, &dnsresources)
 	})
 

--- a/entity/dns_resource.go
+++ b/entity/dns_resource.go
@@ -16,3 +16,10 @@ type DNSResourceParams struct {
 	IPAddresses string `url:"ip_addresses,omitempty"`
 	AddressTTL  int    `url:"address_ttl"`
 }
+
+type DNSResourcesParams struct {
+	All    bool   `url:"all,omitempty"`
+	Domain string `url:"domain,omitempty"`
+	Name   string `url:"name,omitempty"`
+	RRType string `url:"rrtype,omitempty"`
+}

--- a/entity/dns_resource.go
+++ b/entity/dns_resource.go
@@ -18,8 +18,9 @@ type DNSResourceParams struct {
 }
 
 type DNSResourcesParams struct {
-	All    bool   `url:"all,omitempty"`
 	Domain string `url:"domain,omitempty"`
+	FQDN   string `url:"fqdn,omitempty"`
 	Name   string `url:"name,omitempty"`
 	RRType string `url:"rrtype,omitempty"`
+	All    bool   `url:"all,omitempty"`
 }

--- a/entity/dns_resource_record.go
+++ b/entity/dns_resource_record.go
@@ -17,3 +17,9 @@ type DNSResourceRecordParams struct {
 	RRData string `url:"rrdata,omitempty"`
 	TTL    int    `url:"ttl"`
 }
+
+type DNSResourceRecordsParams struct {
+	Domain string `url:"domain,omitempty"`
+	Name   string `url:"name,omitempty"`
+	RRType string `url:"rrtype,omitempty"`
+}

--- a/entity/dns_resource_record.go
+++ b/entity/dns_resource_record.go
@@ -20,6 +20,7 @@ type DNSResourceRecordParams struct {
 
 type DNSResourceRecordsParams struct {
 	Domain string `url:"domain,omitempty"`
+	FQDN   string `url:"fqdn,omitmepty"`
 	Name   string `url:"name,omitempty"`
 	RRType string `url:"rrtype,omitempty"`
 }


### PR DESCRIPTION
- Updating the `DNSResources` and `DNSResourceRecords` Get() apis to accept query params as specified in the [API docs](https://maas.io/docs/api).

Resolves GH: #89 