### PR TITLE
fix: use snake_case for import operations

### DIFF
--- a/client/boot_resources.go
+++ b/client/boot_resources.go
@@ -48,7 +48,7 @@ func (b *BootResources) Import() error {
 // IsImporting returns importing status of boot resources importing to rack controllers
 func (b *BootResources) IsImporting() (bool, error) {
 	isImporting := new(bool)
-	err := b.client().Get("is-importing", url.Values{}, func(data []byte) error {
+	err := b.client().Get("is_importing", url.Values{}, func(data []byte) error {
 		return json.Unmarshal(data, isImporting)
 	})
 
@@ -57,7 +57,7 @@ func (b *BootResources) IsImporting() (bool, error) {
 
 // StopImport stops importing boot resources to rack controllers
 func (b *BootResources) StopImport() error {
-	return b.client().Post("stop-import", url.Values{}, func(data []byte) error {
+	return b.client().Post("stop_import", url.Values{}, func(data []byte) error {
 		return nil
 	})
 }


### PR DESCRIPTION
https://maas.io/docs/api shows the operations use the format `op-snake_case_operation`, which can be verified with your lcoal MAAS:

http://$ip:5240/MAAS/api/2.0/boot-resources/op-is-importing fails, while http://$ip:5240/MAAS/api/2.0/boot-resources/op-is_importing succeeds