### PR TITLE
fix: properly handle VLAN DHCP options

### DIFF
--- a/entity/vlan.go
+++ b/entity/vlan.go
@@ -22,13 +22,13 @@ type VLAN struct {
 // Only the VID field is required. If Space is empty or the string "undefined",
 // the VLAN will be created in the 'undefined' space.
 type VLANParams struct {
-	Name          string `url:"name,omitempty"`
-	Description   string `url:"description,omitempty"`
-	Space         string `url:"space,omitempty"`
-	PrimaryRack   string `url:"primary_rack,omitempty"`
-	SecondaryRack string `url:"secondary_rack,omitempty"`
-	VID           int    `url:"vid,omitempty"`
-	MTU           int    `url:"mtu,omitempty"`
-	RelayVLAN     int    `url:"relay_vlan,omitempty"`
-	DHCPOn        bool   `url:"dhcp_on"`
+	PrimaryRack   *string `url:"primary_rack,omitempty"`
+	SecondaryRack *string `url:"secondary_rack,omitempty"`
+	RelayVLAN     *string `url:"relay_vlan,omitempty"`
+	Name          string  `url:"name,omitempty"`
+	Description   string  `url:"description,omitempty"`
+	Space         string  `url:"space,omitempty"`
+	VID           int     `url:"vid,omitempty"`
+	MTU           int     `url:"mtu,omitempty"`
+	DHCPOn        bool    `url:"dhcp_on"`
 }


### PR DESCRIPTION
## Description of changes

- allow empty primary/secondary rack controller to be set to form data
- convert relay_vlan to `*string` as the only way to unset it in MAAS is to provide an empty string 
- field align the fields after the change

## Issue or ticket link (if applicable)

Resolves: #117

## Checklist

- [x] I have written a PR title that follows the advice in DEVELOPMENT.md with the title format `type: title`
- [x] I have written a description of the changes in the PR that is clear and concise.
- [x] I have updated the documentation to reflect the changes.
- [x] I have added or updated the tests to reflect the changes.
- [x] I have run the unit tests and they pass.
