### PR TITLE
fix: include missing fields on boot-resources objects

### DIFF
--- a/entity/boot_resource.go
+++ b/entity/boot_resource.go
@@ -9,6 +9,7 @@ type BootResource struct {
 	ResourceURI  string                     `json:"resource_uri,omitempty"`
 	LastDeployed string                     `json:"last_deployed,omitempty"`
 	Subarches    string                     `json:"subarches,omitempty"`
+	Title        string                     `json:"title,omitempty"`
 	ID           int                        `json:"id,omitempty"`
 }
 

--- a/entity/boot_resource.go
+++ b/entity/boot_resource.go
@@ -5,6 +5,7 @@ type BootResource struct {
 	Type         string                     `json:"type,omitempty"`
 	Name         string                     `json:"name,omitempty"`
 	Architecture string                     `json:"architecture,omitempty"`
+	BaseImage    string                     `json:"base_image,omitempty"`
 	ResourceURI  string                     `json:"resource_uri,omitempty"`
 	LastDeployed string                     `json:"last_deployed,omitempty"`
 	Subarches    string                     `json:"subarches,omitempty"`

--- a/entity/boot_resource_test.go
+++ b/entity/boot_resource_test.go
@@ -1,0 +1,80 @@
+package entity
+
+import (
+	"testing"
+
+	"github.com/canonical/gomaasclient/test/helper"
+	"github.com/google/go-cmp/cmp"
+)
+
+var sampleBootResource BootResource = BootResource{
+	Sets: map[string]BootResourceSet{
+		"20240828": {
+			Files: map[string]BootResourceSetFile{
+				"root.tgz": {
+					Filename: "root.tgz",
+					Filetype: "root-tgz",
+					SHA256:   "5b341be98b05d409a41ce8c2d881dbd80df9de07da7613d6722d4f0b5e99e0f1",
+					Size:     935047294,
+					Complete: true,
+				},
+			},
+			Version:  "20240828",
+			Label:    "uploaded",
+			Size:     935047294,
+			Complete: true,
+		},
+	},
+	Type:         "Uploaded",
+	Name:         "alma9",
+	Architecture: "amd64/generic",
+	BaseImage:    "rhel/9",
+	ResourceURI:  "/MAAS/api/2.0/boot-resources/13/",
+	Subarches:    "generic",
+	Title:        "Alma 9 Custom",
+	ID:           13,
+}
+
+var sampleBootResources []BootResource = []BootResource{
+	{
+		Type:         "Synced",
+		Name:         "ubuntu/bionic",
+		Architecture: "amd64/ga-18.04",
+		ResourceURI:  "/MAAS/api/2.0/boot-resources/95/",
+		Subarches:    "generic,hwe-p,hwe-q,hwe-r,hwe-s,hwe-t,hwe-u,hwe-v,hwe-w,ga-16.04,ga-16.10,ga-17.04,ga-17.10,ga-18.04",
+		ID:           95,
+	},
+	{
+		Type:         "Uploaded",
+		Name:         "alma9",
+		Architecture: "amd64/generic",
+		BaseImage:    "rhel/9",
+		ResourceURI:  "/MAAS/api/2.0/boot-resources/13/",
+		Subarches:    "generic",
+		Title:        "Alma 9 Custom",
+		ID:           13,
+	},
+}
+
+func TestBootResource(t *testing.T) {
+	br := new(BootResource)
+	brs := new([]BootResource)
+
+	// Unmarshal sample data into the types
+	if err := helper.TestdataFromJSON("maas/boot_resource.json", br); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := helper.TestdataFromJSON("maas/boot_resources.json", brs); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify the values are correct
+	if diff := cmp.Diff(&sampleBootResource, br); diff != "" {
+		t.Fatalf("json.Decode(NetworkInterface) mismatch (-want +got):\n%s", diff)
+	}
+
+	if diff := cmp.Diff(&sampleBootResources, brs); diff != "" {
+		t.Fatalf("json.Decode([]NetworkInterface) mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/test/testdata/maas/boot_resource.json
+++ b/test/testdata/maas/boot_resource.json
@@ -1,0 +1,28 @@
+{
+    "id": 13,
+    "type": "Uploaded",
+    "name": "alma9",
+    "architecture": "amd64/generic",
+    "resource_uri": "/MAAS/api/2.0/boot-resources/13/",
+    "last_deployed": null,
+    "title": "Alma 9 Custom",
+    "subarches": "generic",
+    "base_image": "rhel/9",
+    "sets": {
+        "20240828": {
+            "version": "20240828",
+            "label": "uploaded",
+            "size": 935047294,
+            "complete": true,
+            "files": {
+                "root.tgz": {
+                    "filename": "root.tgz",
+                    "filetype": "root-tgz",
+                    "sha256": "5b341be98b05d409a41ce8c2d881dbd80df9de07da7613d6722d4f0b5e99e0f1",
+                    "size": 935047294,
+                    "complete": true
+                }
+            }
+        }
+    }
+}

--- a/test/testdata/maas/boot_resources.json
+++ b/test/testdata/maas/boot_resources.json
@@ -1,0 +1,22 @@
+[
+    {
+        "id": 95,
+        "type": "Synced",
+        "name": "ubuntu/bionic",
+        "architecture": "amd64/ga-18.04",
+        "resource_uri": "/MAAS/api/2.0/boot-resources/95/",
+        "last_deployed": null,
+        "subarches": "generic,hwe-p,hwe-q,hwe-r,hwe-s,hwe-t,hwe-u,hwe-v,hwe-w,ga-16.04,ga-16.10,ga-17.04,ga-17.10,ga-18.04"
+    },
+    {
+        "id": 13,
+        "type": "Uploaded",
+        "name": "alma9",
+        "architecture": "amd64/generic",
+        "resource_uri": "/MAAS/api/2.0/boot-resources/13/",
+        "last_deployed": null,
+        "title": "Alma 9 Custom",
+        "subarches": "generic",
+        "base_image": "rhel/9"
+    }
+]


### PR DESCRIPTION
## Description of changes

The API v2 can optionally include `base_image`, `title` attributes on boot resources. Update gomaasclient to include these fields.

## Issue or ticket link (if applicable)

Resolves: #120

## Checklist

- [x] I have written a PR title that follows the advice in DEVELOPMENT.md with the title format `type: title`
- [x] I have written a description of the changes in the PR that is clear and concise.
- [x] I have updated the documentation to reflect the changes.
- [x] I have added or updated the tests to reflect the changes.
- [x] I have run the unit tests and they pass.
