### PR TITLE
fix: expect url instead of json for Size in LogicalVolumeParams

### DIFF
--- a/entity/volume_group.go
+++ b/entity/volume_group.go
@@ -39,7 +39,7 @@ type VolumeGroupUpdateParams struct {
 type LogicalVolumeParams struct {
 	Name string `url:"name,omitempty"`
 	UUID string `url:"uuid,omitempty"`
-	Size int64  `json:"size,omitempty"`
+	Size int64  `url:"size,omitempty"`
 }
 
 // VirtualBlockDevice represents a logical volume and extends BlockDevice.


### PR DESCRIPTION
## Description of changes

Fixes a typo in `Size` field of `LogicalVolumeParams` struct so that it is `url` instead of `json`.

### Before the change

```go
logicalVolume, err := client.VolumeGroup.CreateLogicalVolume(machines[0].SystemID, volumeGroup.ID, &entity.LogicalVolumeParams{
	Name: "lvroot",
	Size: 10 * 1024 * 1024 * 1024,
})
if err != nil {
	fmt.Println(err)
}
fmt.Println(logicalVolume.Name)
fmt.Println(logicalVolume.AvailableSize)
```
```bash
$ go run main.go 
vgroot-lvroot
48301604864
```
### After the change

```bash
$ go run main.go 
vgroot-lvroot
10729029632
```

## Issue or ticket link (if applicable)

Resolves: #123 

## Checklist

- [x] I have written a PR title that follows the advice in DEVELOPMENT.md with the title format `type: title`
- [x] I have written a description of the changes in the PR that is clear and concise.
- [x] I have updated the documentation to reflect the changes.
- [x] I have added or updated the tests to reflect the changes.
- [x] I have run the unit tests and they pass.
