### PR TITLE
feat: add-missing-params-for-to-vm-host

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -94,7 +94,7 @@ To test the Go MAAS client:
    go mod tidy
    go run main.go
    ```
-1. You should be able to see MAAS machine info in the output. Congratulations, you've used the GO MAAS client running locally! Modify the client as you see fit and submit a PR. Happy coding! 
+1. You should be able to see MAAS machine info in the output. Congratulations, you've used the Go MAAS client running locally! Modify the client as you see fit and submit a PR. Happy coding! 
 
 ## Testing
 

--- a/entity/vm_host.go
+++ b/entity/vm_host.go
@@ -61,6 +61,7 @@ type VMHostParams struct {
 	Certificate           string  `url:"certificate,omitempty"`
 	MemoryOverCommitRatio float64 `url:"memory_over_commit_ratio,omitempty"`
 	CPUOverCommitRatio    float64 `url:"cpu_over_commit_ratio,omitempty"`
+	Project               string  `url:"project,omitempty"`
 }
 
 // VMHostMachineParams enumerates the VMHost machine configuration options.

--- a/entity/vm_host.go
+++ b/entity/vm_host.go
@@ -59,10 +59,10 @@ type VMHostParams struct {
 	Tags                  string  `url:"tags,omitempty"`
 	DefaultMacvlanMode    string  `url:"default_macvlan_mode,omitempty"`
 	Certificate           string  `url:"certificate,omitempty"`
-	MemoryOverCommitRatio float64 `url:"memory_over_commit_ratio,omitempty"`
-	CPUOverCommitRatio    float64 `url:"cpu_over_commit_ratio,omitempty"`
 	Project               string  `url:"project,omitempty"`
 	Password              string  `url:"password,omitempty"`
+	MemoryOverCommitRatio float64 `url:"memory_over_commit_ratio,omitempty"`
+	CPUOverCommitRatio    float64 `url:"cpu_over_commit_ratio,omitempty"`
 }
 
 // VMHostMachineParams enumerates the VMHost machine configuration options.

--- a/entity/vm_host.go
+++ b/entity/vm_host.go
@@ -62,6 +62,7 @@ type VMHostParams struct {
 	MemoryOverCommitRatio float64 `url:"memory_over_commit_ratio,omitempty"`
 	CPUOverCommitRatio    float64 `url:"cpu_over_commit_ratio,omitempty"`
 	Project               string  `url:"project,omitempty"`
+	Password              string  `url:"password,omitempty"`
 }
 
 // VMHostMachineParams enumerates the VMHost machine configuration options.


### PR DESCRIPTION
## Description of changes

Adds missing params for vm-host

## Issue or ticket link (if applicable)

Enables: https://github.com/canonical/terraform-provider-maas/pull/314

## Checklist

- [x] I have written a PR title that follows the advice in DEVELOPMENT.md with the title format `type: title`
- [x] I have written a description of the changes in the PR that is clear and concise.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have added or updated the tests to reflect the changes.
- [x] I have run the unit tests and they pass.
