### PR TITLE
fix: RAID returns float not int in some cases

### DIFF
--- a/entity/raid.go
+++ b/entity/raid.go
@@ -12,7 +12,8 @@ type RAID struct {
 	SpareDevices  []RAIDDevice `json:"spare_devices,omitempty"`
 	VirtualDevice BlockDevice  `json:"virtual_device,omitempty"`
 	ID            int          `json:"id,omitempty"`
-	Size          int64        `json:"size,omitempty"`
+	// LP:2109708 - this field is a float, not an int, for RAID-10
+	Size          float64      `json:"size,omitempty"`
 }
 
 // RAIDDevice is a combination of a BlockDevice and BlockDevicePartition since a RAID can contain either at devices field

--- a/entity/raid.go
+++ b/entity/raid.go
@@ -1,6 +1,7 @@
 package entity
 
 // RAID represents the MAAS RAID endpoint.
+// LP:2109708 - size field field is a float, not an int, for RAID-10
 type RAID struct {
 	UUID          string       `json:"uuid,omitempty"`
 	Name          string       `json:"name,omitempty"`
@@ -12,7 +13,6 @@ type RAID struct {
 	SpareDevices  []RAIDDevice `json:"spare_devices,omitempty"`
 	VirtualDevice BlockDevice  `json:"virtual_device,omitempty"`
 	ID            int          `json:"id,omitempty"`
-	// LP:2109708 - this field is a float, not an int, for RAID-10
 	Size          float64      `json:"size,omitempty"`
 }
 


### PR DESCRIPTION
## Description of changes

The `size` field in RAID struct returns a `float64` rather than `int64`

*A clear and concise description of your changes here.*

## Issue or ticket link (if applicable)

Resolves #126 
When RAID-10 is selected, the `size` field returns a float, rather than an int due to a bug in MAAS. 

*A link to an issue or ticket that this PR is addressing.*

## Checklist

- [x] I have written a PR title that follows the advice in DEVELOPMENT.md with the title format `type: title`
- [x] I have written a description of the changes in the PR that is clear and concise.
- [x] I have updated the documentation to reflect the changes.
- [x] I have added or updated the tests to reflect the changes.
- [x] I have run the unit tests and they pass.
