### PR TITLE
feat: add active discovery to subnet

### DIFF
--- a/entity/subnet.go
+++ b/entity/subnet.go
@@ -25,16 +25,17 @@ type Subnet struct {
 
 // SubnetParams contains the parameters for the POST operation on the Subnets endpoint.
 type SubnetParams struct {
-	CIDR        string   `url:"cidr"`
-	Name        string   `url:"name,omitempty"`
-	Description string   `url:"description,omitempty"`
-	VLAN        string   `url:"vlan,omitempty"`
-	Fabric      string   `url:"fabric,omitempty"`
-	GatewayIP   string   `url:"gateway_ip,omitempty"`
-	DNSServers  []string `url:"dns_servers,omitempty"`
-	VID         int      `url:"vid,omitempty"`
-	RDNSMode    int      `url:"rdns_mode"`
-	AllowDNS    bool     `url:"allow_dns"`
-	AllowProxy  bool     `url:"allow_proxy"`
-	Managed     bool     `url:"managed"`
+	CIDR            string   `url:"cidr"`
+	Name            string   `url:"name,omitempty"`
+	Description     string   `url:"description,omitempty"`
+	VLAN            string   `url:"vlan,omitempty"`
+	Fabric          string   `url:"fabric,omitempty"`
+	GatewayIP       string   `url:"gateway_ip,omitempty"`
+	DNSServers      []string `url:"dns_servers,omitempty"`
+	VID             int      `url:"vid,omitempty"`
+	RDNSMode        int      `url:"rdns_mode"`
+	AllowDNS        bool     `url:"allow_dns"`
+	AllowProxy      bool     `url:"allow_proxy"`
+	Managed         bool     `url:"managed"`
+	ActiveDiscovery bool     `url:"active_discovery"`
 }


### PR DESCRIPTION
## Description of changes

Adds the `ActiveDiscovery` field to the `SubnetParams`, which connects to the `active_discovery` field in MAAS.

## Issue or ticket link (if applicable)

Resolves: #114 

## Checklist

- [x] I have written a PR title that follows the advice in DEVELOPMENT.md with the title format `type: title`
- [x] I have written a description of the changes in the PR that is clear and concise.
- [x] I have updated the documentation to reflect the changes.
- [x] I have added or updated the tests to reflect the changes.
- [x] I have run the unit tests and they pass.
