### PR TITLE
fix: implement node script entities appropriately

### DIFF
--- a/entity/node_script.go
+++ b/entity/node_script.go
@@ -73,6 +73,10 @@ type NodeScriptHistory struct {
 }
 
 type NodeScriptParams struct {
+	ApplyConfiguredNetworking *bool  `url:"apply_configured_networking"`
+	Destructive               *bool  `url:"destructive"`
+	MayReboot                 *bool  `url:"may_reboot"`
+	Recommission              *bool  `url:"recommission"`
 	ScriptType                string `url:"script_type,omitempty"`
 	HardwareType              string `url:"hardware_type,omitempty"`
 	Parallel                  string `url:"parallel,omitempty"`
@@ -84,10 +88,6 @@ type NodeScriptParams struct {
 	Title                     string `url:"title,omitempty"`
 	Description               string `url:"description,omitempty"`
 	Tags                      string `url:"tags,omitempty"`
-	ApplyConfiguredNetworking *bool  `url:"apply_configured_networking"`
-	Destructive               *bool  `url:"destructive"`
-	MayReboot                 *bool  `url:"may_reboot"`
-	Recommission              *bool  `url:"recommission"`
 }
 
 type NodeScriptReadParams struct {

--- a/entity/node_script.go
+++ b/entity/node_script.go
@@ -1,5 +1,7 @@
 package entity
 
+import "encoding/json"
+
 type NodeScriptType int
 
 // NodeScriptType referring from MAAS server
@@ -36,9 +38,9 @@ const (
 
 // NodeScript represents the MAAS Node Script endpoint.
 type NodeScript struct {
-	Packages                  map[string]interface{} `json:"packages,omitempty"`
-	Results                   map[string]interface{} `json:"results,omitempty"`
-	Parameters                map[string]interface{} `json:":parameters,omitempty"`
+	Packages                  json.RawMessage        `json:"packages,omitempty"`
+	Results                   json.RawMessage        `json:"results,omitempty"`
+	Parameters                json.RawMessage        `json:":parameters,omitempty"`
 	TypeName                  string                 `json:"type_name,omitempty"`
 	HardwareTypeName          string                 `json:"hardware_type_name,omitempty"`
 	ParallelName              string                 `json:"parallel_name,omitempty"`
@@ -71,21 +73,21 @@ type NodeScriptHistory struct {
 }
 
 type NodeScriptParams struct {
-	ScriptType                string   `url:"script_type,omitempty"`
-	HardwareType              string   `url:"hardware_type,omitempty"`
-	Parallel                  string   `url:"parallel,omitempty"`
-	Packages                  string   `url:"packages,omitempty"`
-	Timeout                   string   `url:"timeout,omitempty"`
-	Comment                   string   `url:"comment,omitempty"`
-	ForHardware               string   `url:"for_hardware,omitempty"`
-	Name                      string   `url:"name,omitempty"`
-	Title                     string   `url:"title,omitempty"`
-	Description               string   `url:"description,omitempty"`
-	Tags                      []string `url:"tags,omitempty"`
-	ApplyConfiguredNetworking bool     `url:"apply_configured_networking,omitempty"`
-	Destructive               bool     `url:"destructive,omitempty"`
-	MayReboot                 bool     `url:"may_reboot,omitempty"`
-	Recommission              bool     `url:"recommission,omitempty"`
+	ScriptType                string `url:"script_type,omitempty"`
+	HardwareType              string `url:"hardware_type,omitempty"`
+	Parallel                  string `url:"parallel,omitempty"`
+	Packages                  string `url:"packages,omitempty"`
+	Timeout                   string `url:"timeout,omitempty"`
+	Comment                   string `url:"comment,omitempty"`
+	ForHardware               string `url:"for_hardware,omitempty"`
+	Name                      string `url:"name,omitempty"`
+	Title                     string `url:"title,omitempty"`
+	Description               string `url:"description,omitempty"`
+	Tags                      string `url:"tags,omitempty"`
+	ApplyConfiguredNetworking *bool  `url:"apply_configured_networking"`
+	Destructive               *bool  `url:"destructive"`
+	MayReboot                 *bool  `url:"may_reboot"`
+	Recommission              *bool  `url:"recommission"`
 }
 
 type NodeScriptReadParams struct {


### PR DESCRIPTION
## Description of changes

- Convert `Packages`, `Results`, `Parameters` to `json.RawMessage` so that they can be Marshalled later on
- Convert `NodeScriptParams.Tags` from `[]string` to `string` as the MAAS API v2 expect a single parameter for comma separated tags
- Convert `ApplyConfiguredNetworking`, `Destructive`, `MayReboot`, `Recommission` to `*bool` from `bool` with `omitempty`. By doing so, the users can either skip setting them and rely on script metadata, or setting them back to false during update.

## Issue or ticket link (if applicable)

Resolves: #135

## Checklist

- [x] I have written a PR title that follows the advice in DEVELOPMENT.md with the title format `type: title`
- [x] I have written a description of the changes in the PR that is clear and concise.
- [x] I have updated the documentation to reflect the changes.
- [x] I have added or updated the tests to reflect the changes.
- [x] I have run the unit tests and they pass.
