### PR TITLE
feat: add script to machine release params

### DIFF
--- a/entity/machine.go
+++ b/entity/machine.go
@@ -305,14 +305,14 @@ type MachineDeployParams struct {
 	EphemeralDeploy bool   `url:"ephemeral_deploy,omitempty"`
 }
 
-// MachineReleaseParams enumerates the parameters for the release operation
+// MachineReleaseParams enumerates the parameters for the release operation. `Scripts` is only available for MAAS versions 3.5 and later.
 type MachineReleaseParams struct {
 	Comment     string `url:"comment,omitempty"`
+	Scripts     string `url:"scripts,omitempty"`
 	Erase       bool   `url:"erase,omitempty"`
 	Force       bool   `url:"force,omitempty"`
 	QuickErase  bool   `url:"quick_erase,omitempty"`
 	SecureErase bool   `url:"secure_erase,omitempty"`
-	Scripts     string `url:"scripts,omitempty"`
 }
 
 // MachinePowerOnParams enumerates the parameters for the machine power on operation


### PR DESCRIPTION
## Description of changes

`scripts` is an undocumented parameter, introduced in [3.5](https://canonical.com/maas/docs/reference-release-notes-maas-3-5#p-18070-machine-release-scripts) that allows a user to specify release scripts. This PR adds the ability to specify them.

Testing with an arbitrary unsupported parameter e.g. adding `Unsupported` as a parameter to `MachineReleaseParams`, on my local maas installation running edge, MAAS will not return an error if these parameters are sent to the api via `Machine.Release`. Therefore, this should be backwards compatible with MAAS versions less than 3.5 where release scripts are not supported. 

## Issue or ticket link (if applicable)

Resolves: #143 

## Checklist

- [x] I have written a PR title that follows the advice in DEVELOPMENT.md with the title format `type: title`
- [x] I have written a description of the changes in the PR that is clear and concise.
- [x] I have updated the documentation to reflect the changes.
- [ ] I have added or updated the tests to reflect the changes.
- [x] I have run the unit tests and they pass.
