### PR TITLE
feat: implement the bootresources.Create client for custom image upload

### DIFF
--- a/client/boot_resources.go
+++ b/client/boot_resources.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/url"
 
 	"github.com/canonical/gomaasclient/entity"
@@ -35,7 +34,16 @@ func (b *BootResources) Get(params *entity.BootResourcesReadParams) ([]entity.Bo
 
 // Create creates a new boot source
 func (b *BootResources) Create(params *entity.BootResourceParams) (*entity.BootResource, error) {
-	return nil, fmt.Errorf("not implemented")
+	qsp, err := query.Values(params)
+	if err != nil {
+		return nil, err
+	}
+
+	bootresource := new(entity.BootResource)
+	err = b.client().Post("", qsp, func(body []byte) error {
+		return json.Unmarshal(body, bootresource)
+	})
+	return bootresource, err
 }
 
 // Import imports boot resources to rack controllers


### PR DESCRIPTION
## Description of changes
Got `not implemented` error when using the client to upload custom image to MaaS. This PR implements the client to enable this particular endpoint.

No regression in `make test`

### Sanity Test
The client program with the implemented interface:
```go
	bootresource, err := maasClient.BootResources.Create(&entity.BootResourceParams{
		Name: imageName,
		Architecture: "amd64/generic",
		Filetype:     "tgz",
		Content:      content,
		SHA256:       sha256,
		Size:         fmt.Sprintf("%d", fileSize),
	})
	if err != nil {
		return fmt.Errorf("failed to create boot resource: %v", err)
	}
	log.Printf("Boot resource created: %s\n", bootresource.Name)
```

Execution result:
```
2025/11/05 02:15:28 Boot resource created: publish-maas-sample
```

It seems that the repo doesn't have test for `client`. Let me know if any specific test is required.

## Issue or ticket link (if applicable)
#131 

## Checklist

- [x] I have written a PR title that follows the advice in DEVELOPMENT.md with the title format `type: title`
- [x] I have written a description of the changes in the PR that is clear and concise.
- [x] I have updated the documentation to reflect the changes.
- [x] I have added or updated the tests to reflect the changes.
- [x] I have run the unit tests and they pass.
