### PR TITLE
fix: Corrected "Entering Rescue Mode" status enum name

### DIFF
--- a/entity/node/status.go
+++ b/entity/node/status.go
@@ -32,7 +32,7 @@ const (
 	StatusDiskErasing
 	StatusFailedDiskErasing
 	StatusRescueMode
-	StatusEnteringRescureMode
+	StatusEnteringRescueMode
 	StatusFailedEnteringRescueMode
 	StatusExitingRescueMode
 	StatusFailedExitingRescueMode


### PR DESCRIPTION
## Description of changes

Corrected `StatusEnteringRescureMode` to `StatusEnteringRescueMode`.

## Issue or ticket link (if applicable)

N/A

## Checklist

- [x] I have written a PR title that follows the advice in DEVELOPMENT.md with the title format `type: title`
- [x] I have written a description of the changes in the PR that is clear and concise.
- [x] I have updated the documentation to reflect the changes.
- [x] I have added or updated the tests to reflect the changes.
- [x] I have run the unit tests and they pass.
