### PR TITLE
feat: add is_dpu to machine create parameters

### DIFF
--- a/entity/machine.go
+++ b/entity/machine.go
@@ -249,6 +249,7 @@ type MachineCreateParams struct {
 	SkipNetworking       bool                   `url:"skip_networking,omitempty"`
 	SkipStorage          bool                   `url:"skip_storage,omitempty"`
 	Commission           bool                   `url:"commission,omitempty"`
+	IsDPU                bool                   `url:"is_dpu,omitempty"`
 }
 
 // MachineUpdateParams enumerates the parameters for the machine update operation


### PR DESCRIPTION
## Description of changes

MAAS 3.6+ introduced the `is_dpu` flag for machine enlistment in order to properly enlist and commission DPUs. This PR is adding this parameter in the machine create parameter struct.

## Issue or ticket link (if applicable)

Enabler for: https://github.com/canonical/terraform-provider-maas/issues/420

## Checklist

- [x] I have written a PR title that follows the advice in DEVELOPMENT.md with the title format `type: title`
- [x] I have written a description of the changes in the PR that is clear and concise.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have added or updated the tests to reflect the changes.
- [x] I have run the unit tests and they pass.
